### PR TITLE
Clear selections when category changes.

### DIFF
--- a/packages/attribute-slicer-powerbi/src/AttributeSlicerVisual.ts
+++ b/packages/attribute-slicer-powerbi/src/AttributeSlicerVisual.ts
@@ -304,19 +304,25 @@ export default class AttributeSlicer extends VisualBase {
 
                     delete this.loadDeferred;
                 }
-
-                const columnName = ldget(dv, "categorical.categories[0].source.queryName");
-
+               
+                var columnNames : Array<String> = [];
+                _.forOwn(ldget(dv,"categorical.categories"),(value,key: any) => {
+                    columnNames.push(value.source.queryName);
+                })
+                
                 // Only clear selection IF
                 // We've already loaded a dataset, and the user has changed the dataset to something else
-                if (this.currentCategory && (!columnName || this.currentCategory !== columnName)) {
+                if (this.currentCategory && (!columnNames || !_.isEqual(this.currentCategory,columnNames)))  {
                     // This will really be undefined behaviour for pbi-stateful because this indicates the user changed datasets
                     log("Clearing Selection, Categories Changed");
-                    pbiState.selectedItems = [];
-                    pbiState.searchText = "";
+                    if (!_.isEqual(pbiState.selectedItems,[])){
+                        pbiState.selectedItems = [];
+                        this._onSelectionChangedDebounced([])
+                    }
+                    pbiState.searchText = "";                  
                 }
 
-                this.currentCategory = columnName;
+                this.currentCategory = columnNames;
             }
         } else {
             this.mySlicer.data = [];

--- a/packages/attribute-slicer-powerbi/src/AttributeSlicerVisual.ts
+++ b/packages/attribute-slicer-powerbi/src/AttributeSlicerVisual.ts
@@ -304,22 +304,22 @@ export default class AttributeSlicer extends VisualBase {
 
                     delete this.loadDeferred;
                 }
-               
-                var columnNames : Array<String> = [];
-                _.forOwn(ldget(dv,"categorical.categories"),(value,key: any) => {
+
+                const columnNames: Array<String> = [];
+                _.forOwn(ldget(dv, "categorical.categories"), (value, key: any) => {
                     columnNames.push(value.source.queryName);
-                })
-                
+                });
+
                 // Only clear selection IF
                 // We've already loaded a dataset, and the user has changed the dataset to something else
-                if (this.currentCategory && (!columnNames || !_.isEqual(this.currentCategory,columnNames)))  {
+                if (this.currentCategory && (!columnNames || !_.isEqual(this.currentCategory, columnNames)))  {
                     // This will really be undefined behaviour for pbi-stateful because this indicates the user changed datasets
                     log("Clearing Selection, Categories Changed");
-                    if (!_.isEqual(pbiState.selectedItems,[])){
+                    if (!_.isEqual(pbiState.selectedItems, [])) {
                         pbiState.selectedItems = [];
-                        this._onSelectionChangedDebounced([])
+                        this._onSelectionChangedDebounced([]);
                     }
-                    pbiState.searchText = "";                  
+                    pbiState.searchText = "";
                 }
 
                 this.currentCategory = columnNames;

--- a/packages/attribute-slicer-powerbi/src/AttributeSlicerVisual.ts
+++ b/packages/attribute-slicer-powerbi/src/AttributeSlicerVisual.ts
@@ -312,7 +312,7 @@ export default class AttributeSlicer extends VisualBase {
 
                 // Only clear selection IF
                 // We've already loaded a dataset, and the user has changed the dataset to something else
-                if (this.currentCategory && (!columnNames || !_.isEqual(this.currentCategory, columnNames)))  {
+                if (this.currentCategory && !_.isEqual(this.currentCategory, columnNames))  {
                     // This will really be undefined behaviour for pbi-stateful because this indicates the user changed datasets
                     log("Clearing Selection, Categories Changed");
                     if (!_.isEqual(pbiState.selectedItems, [])) {


### PR DESCRIPTION
- Support multiple categories.
- add call to _onSelectionChangeDebounced to change the selection in
power bi when categories change.