### PR TITLE
Feature/shift select

### DIFF
--- a/packages/attribute-slicer/src/selection/JQuerySelectionManager.ts
+++ b/packages/attribute-slicer/src/selection/JQuerySelectionManager.ts
@@ -188,6 +188,10 @@ export default class JQuerySelectionManager<T extends ISelectableItem<any>> exte
                 })
                 .on(`click${EVENTS_NS}`, function (e) {
                     e.stopPropagation();
+                    that.keyPressed({
+                        ctrl: e.ctrlKey,
+                        shift: e.shiftKey,
+                    });
                     that.itemClicked(that.eleItemGetter($(this)));
                 })
                 .each((idx, ele) => {

--- a/packages/attribute-slicer/src/selection/JQuerySelectionManager.ts
+++ b/packages/attribute-slicer/src/selection/JQuerySelectionManager.ts
@@ -39,25 +39,6 @@ export default class JQuerySelectionManager<T extends ISelectableItem<any>> exte
     private lastMouseDownY: number;
     private mouseDownEle: JQuery;
 
-    /**
-     * Constructor
-     */
-    constructor(onSelectionChanged?: (items: T[]) => any) {
-        super(onSelectionChanged);
-
-        const updateKeyState = (e: JQueryEventObject) => {
-            this.keyPressed({
-                ctrl: e.ctrlKey,
-                shift: e.shiftKey,
-            });
-        };
-
-        $(window)
-            .on(`keydown${EVENTS_NS}`, updateKeyState)
-            .on(`keyup${EVENTS_NS}`, updateKeyState)
-            .on(`focus${EVENTS_NS}`, updateKeyState)
-            .on(`blur${EVENTS_NS}`, updateKeyState);
-    }
 
     /**
      * Will bind event listeners to the given set of elements


### PR DESCRIPTION
closes #52 
Detect key presses from the click event instead of monitoring for keyup / keydown events on the window object ( which we are no longer receiving.  )