### PR TITLE
add option to show/hide search box

### DIFF
--- a/packages/attribute-slicer-powerbi/src/state.ts
+++ b/packages/attribute-slicer-powerbi/src/state.ts
@@ -91,7 +91,7 @@ export default class AttributeSlicerVisualState extends HasSettings implements I
             return doesDataSupportSearch(dv) && !isSelfFilterEnabled;
         },
     })
-    public showSearch?: boolean;
+    public searchEnabled?: boolean;
 
     /**
      * If we are being rendered horizontally
@@ -189,6 +189,16 @@ export default class AttributeSlicerVisualState extends HasSettings implements I
         defaultValue: DEFAULT_STATE.showOptions,
     })
     public showOptions?: boolean;
+
+    /**
+     * If we should show the search box
+     */
+    @setting({
+        displayName: "Show Search",
+        description: "Show the search box.",
+        defaultValue: DEFAULT_STATE.showSearch,
+    })
+    public showSearch?: boolean;
 
     /**
      * The display units to use when rendering values

--- a/packages/attribute-slicer-powerbi/src/state.ts
+++ b/packages/attribute-slicer-powerbi/src/state.ts
@@ -82,7 +82,7 @@ export default class AttributeSlicerVisualState extends HasSettings implements I
     public showValues?: boolean;
 
     /**
-     * Whether or not the search box should be shown
+     * Whether or not data supports search
      */
     @setting({
         persist: false, // Don't persist this setting, it is dynamic based on the dataview
@@ -91,7 +91,7 @@ export default class AttributeSlicerVisualState extends HasSettings implements I
             return doesDataSupportSearch(dv) && !isSelfFilterEnabled;
         },
     })
-    public searchEnabled?: boolean;
+    public searchSupported?: boolean;
 
     /**
      * If we are being rendered horizontally

--- a/packages/attribute-slicer/src/AttributeSlicer.defaults.ts
+++ b/packages/attribute-slicer/src/AttributeSlicer.defaults.ts
@@ -56,6 +56,7 @@ export const DEFAULT_STATE: IAttributeSlicerState = {
     leftAlignText: false,
     showOptions: true,
     showSearch: true,
+    searchEnabled: true,
     showValues: true,
     scrollPosition: [0, 0],
     displayValueLabels: false,

--- a/packages/attribute-slicer/src/AttributeSlicer.defaults.ts
+++ b/packages/attribute-slicer/src/AttributeSlicer.defaults.ts
@@ -56,7 +56,7 @@ export const DEFAULT_STATE: IAttributeSlicerState = {
     leftAlignText: false,
     showOptions: true,
     showSearch: true,
-    searchEnabled: true,
+    searchSupported: true,
     showValues: true,
     scrollPosition: [0, 0],
     displayValueLabels: false,

--- a/packages/attribute-slicer/src/AttributeSlicer.ts
+++ b/packages/attribute-slicer/src/AttributeSlicer.ts
@@ -289,6 +289,7 @@ export class AttributeSlicer {
             leftAlignText: this.leftAlignText,
             showOptions: this.showOptions,
             showSearch: this.showSearchBox,
+            searchEnabled: this.showSearchBox,
             showValues: this.showValues,
             scrollPosition: this.scrollPosition,
             displayValueLabels: this.displayValueLabels,
@@ -326,7 +327,7 @@ export class AttributeSlicer {
         s.brushSelectionMode = state.brushMode;
         s.showSelections = state.showSelections;
         s.showOptions = state.showOptions;
-        s.showSearchBox = state.showSearch;
+        s.showSearchBox = state.showSearch && state.searchEnabled;
         s.showValues = state.showValues;
         const newSearchString = state.searchText;
         let searchString = false;

--- a/packages/attribute-slicer/src/AttributeSlicer.ts
+++ b/packages/attribute-slicer/src/AttributeSlicer.ts
@@ -289,7 +289,7 @@ export class AttributeSlicer {
             leftAlignText: this.leftAlignText,
             showOptions: this.showOptions,
             showSearch: this.showSearchBox,
-            searchEnabled: this.showSearchBox,
+            searchSupported: this.showSearchBox,
             showValues: this.showValues,
             scrollPosition: this.scrollPosition,
             displayValueLabels: this.displayValueLabels,
@@ -327,7 +327,7 @@ export class AttributeSlicer {
         s.brushSelectionMode = state.brushMode;
         s.showSelections = state.showSelections;
         s.showOptions = state.showOptions;
-        s.showSearchBox = state.showSearch && state.searchEnabled;
+        s.showSearchBox = state.showSearch && state.searchSupported;
         s.showValues = state.showValues;
         const newSearchString = state.searchText;
         let searchString = false;

--- a/packages/attribute-slicer/src/interfaces.ts
+++ b/packages/attribute-slicer/src/interfaces.ts
@@ -151,6 +151,11 @@ export interface IAttributeSlicerState {
     showSearch?: boolean;
 
     /**
+     * If search is supported for the data
+     */
+    searchEnabled?: boolean;
+
+    /**
      * If we should show the values column
      */
     showValues?: boolean;

--- a/packages/attribute-slicer/src/interfaces.ts
+++ b/packages/attribute-slicer/src/interfaces.ts
@@ -153,7 +153,7 @@ export interface IAttributeSlicerState {
     /**
      * If search is supported for the data
      */
-    searchEnabled?: boolean;
+    searchSupported?: boolean;
 
     /**
      * If we should show the values column


### PR DESCRIPTION
closes #50
Renames old showSearch option to searchEnabled (automatically detects
if search filtering is supported for the data) and add new setting to
show / hide the search box.

Search box is only shown if both searchEnabled and showSearch are true.