### PR TITLE
option for value text overflow

### DIFF
--- a/packages/attribute-slicer-powerbi/src/state.ts
+++ b/packages/attribute-slicer-powerbi/src/state.ts
@@ -264,6 +264,17 @@ export default class AttributeSlicerVisualState extends HasSettings implements I
     public displayValueLabels?: boolean;
 
     /**
+     * If the value text overflow should be visible 
+     */
+    @setting({
+        category: "Display",
+        displayName: "Overflow value text",
+        description: "Allow value text to overflow the bar.",
+        defaultValue: DEFAULT_STATE.overflowValueLabels,
+    })
+    public overflowValueLabels?: boolean;
+
+    /**
      * The set of settings for the colored objects
      */
     @coloredObjectsSettings({

--- a/packages/attribute-slicer/src/AttributeSlicer.defaults.ts
+++ b/packages/attribute-slicer/src/AttributeSlicer.defaults.ts
@@ -59,4 +59,5 @@ export const DEFAULT_STATE: IAttributeSlicerState = {
     showValues: true,
     scrollPosition: [0, 0],
     displayValueLabels: false,
+    overflowValueLabels: false,
 };

--- a/packages/attribute-slicer/src/AttributeSlicer.ts
+++ b/packages/attribute-slicer/src/AttributeSlicer.ts
@@ -171,6 +171,26 @@ export class AttributeSlicer {
     }
 
     /**
+     * Wheter or not to set value text overflow to visible
+     */
+    private _overflowValueLabels = false;
+    public get overflowValueLabels() {
+        return this._overflowValueLabels;
+    }
+
+    /**
+     * Sets wheter or not to use allow value text to overflow
+     */
+    public set overflowValueLabels(shouldOverflow: boolean) {
+        if (shouldOverflow !== this._overflowValueLabels) {
+            this._overflowValueLabels = shouldOverflow;
+            if (this.virtualList) {
+                this.virtualList.rerender();
+            }
+        }
+    }
+
+    /**
      * Font color used to display item text
      */
     private _itemTextColor = "#000";
@@ -218,7 +238,8 @@ export class AttributeSlicer {
             afterRender: () => this.selectionManager.refresh(),
             generatorFn: (i: number) => {
                 const item: SlicerItem = this.virtualList.items[i];
-                const ele = itemTemplate(item, this.calcColumnSizes(), this.leftAlignText, this.displayValueLabels, this.itemTextColor);
+                const ele = itemTemplate(item, this.calcColumnSizes(), this.leftAlignText,
+                    this.displayValueLabels, this.itemTextColor, this.overflowValueLabels);
                 ele
                     .css({ height: `${this.virtualList.itemHeight - 4}px`, paddingBottom: "2.5px", paddingTop: "2px" })
                     .data("item", item);
@@ -293,6 +314,7 @@ export class AttributeSlicer {
             scrollPosition: this.scrollPosition,
             displayValueLabels: this.displayValueLabels,
             itemTextColor: this.itemTextColor,
+            overflowValueLabels: this.overflowValueLabels,
         };
     }
 
@@ -347,6 +369,7 @@ export class AttributeSlicer {
         this.leftAlignText = state.leftAlignText;
         this.displayValueLabels = state.displayValueLabels;
         this.itemTextColor = state.itemTextColor;
+        this.overflowValueLabels = state.overflowValueLabels;
 
         this.loadingState = false;
     }

--- a/packages/attribute-slicer/src/SlicerItem.tmpl.ts
+++ b/packages/attribute-slicer/src/SlicerItem.tmpl.ts
@@ -31,7 +31,7 @@ import * as d3 from "d3";
  * Returns an element for the given item
  */
 export default function (item: SlicerItem, sizes: { category: number; value: number }, alignTextLeft?: boolean,
-        showValueLabels?: boolean, itemTextColor?: string) {
+        showValueLabels?: boolean, itemTextColor?: string, textOverflow?: boolean) {
     "use strict";
     const { match, matchPrefix, matchSuffix, valueSegments, renderedValue } = item;
     const alignStyle = alignTextLeft ? "text-align:left;" : "";
@@ -47,7 +47,7 @@ export default function (item: SlicerItem, sizes: { category: number; value: num
                 </span>
                 <span style="display:inline-block;max-width:${sizes.value}%;height:100%" class="value-container">
                     <span style="display:inline-block;width:${renderedValue}%;height:100%">
-                    ${ valueSegmentsTemplate(valueSegments, showValueLabels) }
+                    ${ valueSegmentsTemplate(valueSegments, showValueLabels, textOverflow) }
                     </span>
                 </span>
             </div>
@@ -58,7 +58,7 @@ export default function (item: SlicerItem, sizes: { category: number; value: num
 /**
  * Template string for the given valueSegments
  */
-function valueSegmentsTemplate(valueSegments: ISlicerValueSegment[], showValueLabels: boolean) {
+function valueSegmentsTemplate(valueSegments: ISlicerValueSegment[], showValueLabels: boolean, textOverflow: boolean) {
     "use strict";
     return (valueSegments || []).filter(n => n.width > 0).map(s => {
         const { color, highlightWidth } = s;
@@ -87,11 +87,16 @@ function valueSegmentsTemplate(valueSegments: ISlicerValueSegment[], showValueLa
 
         const displayValue = s.displayValue || s.value || "0";
         const style = `display:inline-block;width:${s.width}%;${backgroundColor};height:100%;position:relative;color:${fontColor}`;
-        const spanclass = showValueLabels ? "always-display value" : "value";
+        let barSpanClass = "value-display";
+        let textSpanclass = showValueLabels ? "always-display value" : "value";
+        if (textOverflow) {
+            barSpanClass += " overflow";
+            textSpanclass += " overflow";
+        }
         return `
-            <span style="${style}" title="${(s["name"] ? s["name"] + " - " : "") + displayValue}" class="value-display">
+            <span style="${style}" title="${(s["name"] ? s["name"] + " - " : "") + displayValue}" class="${barSpanClass}" >
                 ${ highlightsTemplate(s) }
-                &nbsp;<span class="${spanclass}">${displayValue}</span>
+                &nbsp;<span class="${textSpanclass}">${displayValue}</span>
             </span>
         `.trim().replace(/\n/g, "");
     }).join("");

--- a/packages/attribute-slicer/src/css/Base.scss
+++ b/packages/attribute-slicer/src/css/Base.scss
@@ -271,6 +271,9 @@
   .value-display {
     overflow: hidden;
   }
+  .overflow {
+    overflow: visible !important;
+  }
 
   .value-display .always-display.value, .item:hover .value-display .value {
       display: inline-block;

--- a/packages/attribute-slicer/src/interfaces.ts
+++ b/packages/attribute-slicer/src/interfaces.ts
@@ -198,4 +198,9 @@ export interface IAttributeSlicerState {
      * If we should always display values text
      */
     displayValueLabels?: boolean;
+
+    /**
+     * If we should allow value text to overflow and be visible
+     */
+    overflowValueLabels?: boolean;
 }


### PR DESCRIPTION
closes #54 

Adds an option in the display settings to allow the value text overflow to be visible.  This allows users to see the values associated with very small bars.  This option does not work well with multiple segments, but is an available for those who wish to use it.  